### PR TITLE
fix gpusim_search.py

### DIFF
--- a/python/gpusim_search.py
+++ b/python/gpusim_search.py
@@ -16,10 +16,8 @@ def main():
         return_count = 20
         similarity_cutoff = 0
 
-        fp_binary = smiles_to_fingerprint_bin(smiles)
-        #fp_qba = QtCore.QByteArray(fp_binary)
-        fp_qba = QtCore.QByteArray()
-        fp_qba.append(fp_binary[0])
+        fp_binary, canon_smiles = smiles_to_fingerprint_bin(smiles)
+        fp_qba = QtCore.QByteArray(fp_binary)
 
         output_qba = QtCore.QByteArray()
         output_qds = QtCore.QDataStream(output_qba, QtCore.QIODevice.WriteOnly)

--- a/python/gpusim_search.py
+++ b/python/gpusim_search.py
@@ -17,7 +17,9 @@ def main():
         similarity_cutoff = 0
 
         fp_binary = smiles_to_fingerprint_bin(smiles)
-        fp_qba = QtCore.QByteArray(fp_binary)
+        #fp_qba = QtCore.QByteArray(fp_binary)
+        fp_qba = QtCore.QByteArray()
+        fp_qba.append(fp_binary[0])
 
         output_qba = QtCore.QByteArray()
         output_qds = QtCore.QDataStream(output_qba, QtCore.QIODevice.WriteOnly)
@@ -36,6 +38,7 @@ def main():
         ids = []
 
         data_reader = QtCore.QDataStream(output_qba)
+        return_count = data_reader.readInt()
 
         for i in range(return_count):
             smiles.append(data_reader.readString())

--- a/python/gpusim_server.py
+++ b/python/gpusim_server.py
@@ -51,7 +51,7 @@ class GPUSimHandler(BaseHTTPRequestHandler):
 
     def get_data(self, socket_name, src_smiles, return_count,
                  similarity_cutoff):
-        fp_binary = gpusim_utils.smiles_to_fingerprint_bin(src_smiles)
+        fp_binary, canon_smile = gpusim_utils.smiles_to_fingerprint_bin(src_smiles)
         fp_qba = QtCore.QByteArray(fp_binary)
 
         output_qba = QtCore.QByteArray()


### PR DESCRIPTION
fixed gpusim_search.py to work with the example in README.md

Version tested:
PyQt5              5.12.1     
Python             3.7.1

Commands to reproduce error:

    cd build/
    ./gpusimserver test/small.fsim &
    python python/gpusim_search.py small
    Smiles: CCCc1c2c(n(n1)C)n(c(n2)N)c3ccccc3

