### PR TITLE
Add a recipe to build a docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Architecture and benchmarks were presented in [a presentation at the 2018 RDKit 
 
 ## Basic Benchmark
 
-On a machine with four Tesla V100, searching one billion compounds takes ~0.4 seconds.
+On a machine with four Tesla V100, searching one billion compounds takes ~0.2 seconds.
 
-See [RDKit Presentation](gpusimilarity_rdkit_presentation.pdf) for much more in depth benchmarks.
+See [RDKit Presentation](gpusimilarity_rdkit_presentation.pdf) for much more in depth benchmarks (that are slightly out of date).
 
 ## Example integration
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ Here is a video of this backend being utilized for immediate-response searching 
 
 [![GPUSimilarity Gadget](http://img.youtube.com/vi/DZhknAXXEo4/0.jpg)](https://www.youtube.com/watch?v=T11UXEoF_rk)
 
-## Dependencies
+## Using GPUSimilarity
+**It is highly recommended that you use docker for building/running.**
+
+See [Our Docker Readme](docker/)
+
+## Dependencies for Building (recommended only for development)
 * RDKit (At Python level, not compilation)
 * Qt 5.2+ (including QtNetwork)
 * PyQt
@@ -27,6 +32,7 @@ Here is a video of this backend being utilized for immediate-response searching 
 * Optional: Doxygen for generating documents
 
 ## Building with CMake and running unit tests with CTest
+**Recommended only for development, see Docker**
 ```
 From parent directory of source:
 mkdir bld
@@ -48,6 +54,7 @@ make doc_doxygen
 The result is in bld/doc/html
 
 ## Running
+**Recommended only for development, see Docker**
 ### For basic json-response http endpoint:
 From build directory:
 `python3 ${SRC_DIR}/python/gpusim_server.py <fingerprint fsim file>`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,12 @@ RUN wget https://github.com/rdkit/rdkit/archive/Release_2019_03_1.tar.gz && \
     make && make install && cd / && rm -rf Release_2019_03_1.tar.gz  \
     rdkit-Release_2019_03_1
 
+# IMPORTANT:  Change this to remote branch you want to build
 ENV BRANCH=docker
 
 # Used to prevent github cache from stopping rebuild when branch changes
 ADD https://api.github.com/repos/schrodinger/gpusimilarity/git/refs/heads/$BRANCH version.txt
 
-# Use specific hash/version in checkout to ensure cacheing works
 RUN git clone https://github.com/schrodinger/gpusimilarity.git && \
     cd gpusimilarity && \
     git checkout $BRANCH && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@ ENV RDBASE=/rdkit-Release_2019_03_1
 RUN wget https://github.com/rdkit/rdkit/archive/Release_2019_03_1.tar.gz && \
     tar zxvf Release_2019_03_1.tar.gz && cd rdkit-Release_2019_03_1 && \
     mkdir bld && cd bld && cmake -DRDK_INSTALL_INTREE=OFF \
-    -DCMAKE_INSTALL_PREFIX=/usr -DPYTHON_EXECUTABLE=/usr/bin/python3 .. && \
+    -DCMAKE_INSTALL_PREFIX=/usr -DPYTHON_EXECUTABLE=/usr/bin/python3 \
+    -DRDK_INSTALL_STATIC_LIBS=OFF -DRDK_BUILD_CPP_TESTS=OFF .. && \
     make && make install && cd / && rm -rf Release_2019_03_1.tar.gz  \
     rdkit-Release_2019_03_1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:9.2-devel-ubuntu18.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-libraries-$CUDA_PKG_VERSION qt5-default cmake python3-pyqt5 \
+        libboost-all-dev git wget python3-numpy && apt-get clean
+
+ENV RDBASE=/rdkit-Release_2019_03_1
+RUN wget https://github.com/rdkit/rdkit/archive/Release_2019_03_1.tar.gz && \
+    tar zxvf Release_2019_03_1.tar.gz && cd rdkit-Release_2019_03_1 && \
+    mkdir bld && cd bld && cmake -DRDK_INSTALL_INTREE=OFF \
+    -DCMAKE_INSTALL_PREFIX=/usr -DPYTHON_EXECUTABLE=/usr/bin/python3 .. && \
+    make && make install && cd / && rm -rf Release_2019_03_1.tar.gz  \
+    rdkit-Release_2019_03_1
+
+RUN git clone https://github.com/schrodinger/gpusimilarity.git && \
+    mkdir bld && cd bld && cmake ../gpusimilarity && make -j5
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,9 @@ RUN wget https://github.com/rdkit/rdkit/archive/Release_2019_03_1.tar.gz && \
     make && make install && cd / && rm -rf Release_2019_03_1.tar.gz  \
     rdkit-Release_2019_03_1
 
+# Use specific hash/version in checkout to ensure cacheing works
 RUN git clone https://github.com/schrodinger/gpusimilarity.git && \
-    mkdir bld && cd bld && cmake ../gpusimilarity && make -j5
+    cd gpusimilarity && \
+    git checkout 1570f5c46ff21a6ae8238a28ca0fa3a13d8e87ac && \
+    mkdir bld && cd bld && cmake ../ && make -j5
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,9 +12,14 @@ RUN wget https://github.com/rdkit/rdkit/archive/Release_2019_03_1.tar.gz && \
     make && make install && cd / && rm -rf Release_2019_03_1.tar.gz  \
     rdkit-Release_2019_03_1
 
+ENV BRANCH=docker
+
+# Used to prevent github cache from stopping rebuild when branch changes
+ADD https://api.github.com/repos/schrodinger/gpusimilarity/git/refs/heads/$BRANCH version.txt
+
 # Use specific hash/version in checkout to ensure cacheing works
 RUN git clone https://github.com/schrodinger/gpusimilarity.git && \
     cd gpusimilarity && \
-    git checkout 1570f5c46ff21a6ae8238a28ca0fa3a13d8e87ac && \
+    git checkout $BRANCH && \
     mkdir bld && cd bld && cmake ../ && make -j5
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,7 +34,7 @@ TODO
 ```
 /bin/nvidia-docker run --net=host -v /path/to/fsim/files:/mnt/fsim -it \
 klorton/gpusimilarity:latest python3 /gpusimilarity/bld/python/gpusim_server.py \
-/path/to/fsim/files/1.fsim --port 8080 --http_interface
+/mnt/fsim/1.fsim --port 8080 --http_interface
 ```
 
 ## Example of a systemd configuration file

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,9 +13,15 @@ built to produce an image capable of running GPUSimilarity.
 Both releases and master are always built and uploaded publicly already.  You
 can access them via:
 For master:
-`docker pull klorton/gpusimilarity:latest`
+```
+docker pull klorton/gpusimilarity:latest
+```
+
 For releases:
-`docker pull klorton/gpusimilarity:v1.0`
+
+```
+docker pull klorton/gpusimilarity:v1.0
+```
 
 The underlying requirements will change very little, so after the initial
 build/pull new docker layers will only require a few megabytes for

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ The preferred method of using Docker is to just to download the publicly
 released pre-built docker images.  In addition, the enclosed Dockerfile can be
 built to produce an image capable of running GPUSimilarity.
 
-##Requirements
+## Requirements
 * nvidia-docker (regular docker will not expose GPUs)
 * Newest versions of nvidia drivers
 * Recommended for production:  systemd / nginx

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,12 +4,15 @@ The enclosed Docker file can be built with nvidia-docker to produce an
 image capable of running GPUSimilarity.
 
 ## How to build
+From the docker directory:
+```docker build -t gpusim:internal .```
 
 ## How to execute to build a fingerprint file
 
 ## How to execute to start a gpusimilarity server
 
 ## Additional steps you'll want to take for production
+
 
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,18 +1,60 @@
-# gpusimilarity Docker Image Generation
+# gpusimilarity Docker Container
 
-The enclosed Docker file can be built with nvidia-docker to produce an
-image capable of running GPUSimilarity.
+The preferred method of using Docker is to just to download the publicly
+released pre-built docker images.  In addition, the enclosed Dockerfile can be
+built to produce an image capable of running GPUSimilarity.
 
-## How to build
+##Requirements
+* nvidia-docker (regular docker will not expose GPUs)
+* Newest versions of nvidia drivers
+* Recommended for production:  systemd / nginx
+
+## How to use pre-built container
+Both releases and master are always built and uploaded publicly already.  You
+can access them via:
+For master:
+`docker pull klorton/gpusimilarity:latest`
+For releases:
+`docker pull klorton/gpusimilarity:v1.0`
+
+The underlying requirements will change very little, so after the initial
+build/pull new docker layers will only require a few megabytes for
+gpusimilarity changes.
+
+## How to build (recommended only for development)
 From the docker directory:
-```docker build -t gpusim:internal .```
+```
+docker build -t gpusim:internal .
+```
 
-## How to execute to build a fingerprint file
+## How to use to build a fingerprint file
+TODO
 
-## How to execute to start a gpusimilarity server
+## How to start a gpusimilarity server interactively
+```
+/bin/nvidia-docker run --net=host -v /path/to/fsim/files:/mnt/fsim -it \
+klorton/gpusimilarity:latest bash -c 'python3 /gpusimilarity/bld/python/gpusim_server.py \
+/path/to/fsim/files/1.fsim --port 8080 --http_interface'
+```
+
+## Example of a systemd configuration file
+```
+[Unit]
+Description=Service to return GPUSimilarity results
+After=docker.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+User=gpusim
+ExecStart=/bin/nvidia-docker run --net=host -v /path/to/fsim:/mnt/fsim klorton/gpusimilarity:latest python3 /gpusimilarity/bld/python/gpusim_server.py --port 8080 /mnt/fsim/your_file.fsim
+
+[Install]
+WantedBy=multi-user.target
+```
 
 ## Additional steps you'll want to take for production
-
-
-
-
+* The `--http_interface` option is only for testing **never** use it in production as it hasn't been hardened at all
+* You should use a systemd script to start/stop the service, including restarts
+* **Never** expose the http from this service directly, use nginx or equivalent with certificates to expose via ssl/https.

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,7 +34,15 @@ docker build -t gpusim:internal .
 ```
 
 ## How to use to build a fingerprint file
-TODO
+```
+docker run -v /PATH/TO/SMIGZ_DIR:/data -it gpusim python3 \
+/gpusimilarity/bld/python/gpusim_createdb.py /data/INPUT.smi.gz \
+/data/OUTPUT.fsim
+```
+
+This will run single threaded.  If you're building huge databases you should
+enter the container interactively with the data directory mounted, and follow
+the regular instructions from the parent ReadMe to run multithreaded.
 
 ## How to start a gpusimilarity server interactively
 ```
@@ -43,10 +51,14 @@ klorton/gpusimilarity:latest python3 /gpusimilarity/bld/python/gpusim_server.py 
 /mnt/fsim/1.fsim --port 8080 --http_interface
 ```
 
+Once the server says "Ready for Searches", you should be able to test it by
+either using a graphical web browser or links to access "http://localhost:8080"
+
 ## Example of a systemd configuration file
 See [the provided service file](gpusimilarity.service) to be placed in `/etc/systemd/system/`
 
 ## Additional steps you'll want to take for production
-* The `--http_interface` option is only for testing **never** use it in production as it hasn't been hardened at all
+* The `--http_interface` option is only for testing **never** use it in
+  production as it hasn't been hardened at all
 * You should use a systemd script to start/stop the service, including restarts
 * **Never** expose the http from this service directly, use nginx or equivalent with certificates to expose via ssl/https.

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,8 +33,8 @@ TODO
 ## How to start a gpusimilarity server interactively
 ```
 /bin/nvidia-docker run --net=host -v /path/to/fsim/files:/mnt/fsim -it \
-klorton/gpusimilarity:latest bash -c 'python3 /gpusimilarity/bld/python/gpusim_server.py \
-/path/to/fsim/files/1.fsim --port 8080 --http_interface'
+klorton/gpusimilarity:latest python3 /gpusimilarity/bld/python/gpusim_server.py \
+/path/to/fsim/files/1.fsim --port 8080 --http_interface
 ```
 
 ## Example of a systemd configuration file

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+# gpusimilarity Docker Image Generation
+
+The enclosed Docker file can be built with nvidia-docker to produce an
+image capable of running GPUSimilarity.
+
+## How to build
+
+## How to execute to build a fingerprint file
+
+## How to execute to start a gpusimilarity server
+
+## Additional steps you'll want to take for production
+
+
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,21 +44,7 @@ klorton/gpusimilarity:latest python3 /gpusimilarity/bld/python/gpusim_server.py 
 ```
 
 ## Example of a systemd configuration file
-```
-[Unit]
-Description=Service to return GPUSimilarity results
-After=docker.service
-
-[Service]
-Type=simple
-Restart=always
-RestartSec=10
-User=gpusim
-ExecStart=/bin/nvidia-docker run --net=host -v /path/to/fsim:/mnt/fsim klorton/gpusimilarity:latest python3 /gpusimilarity/bld/python/gpusim_server.py --port 8080 /mnt/fsim/your_file.fsim
-
-[Install]
-WantedBy=multi-user.target
-```
+See [the provided service file](gpusimilarity.service) to be placed in `/etc/systemd/system/`
 
 ## Additional steps you'll want to take for production
 * The `--http_interface` option is only for testing **never** use it in production as it hasn't been hardened at all

--- a/docker/gpusimilarity.service
+++ b/docker/gpusimilarity.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Service to return GPUSimilarity results
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+TimeoutStartSec=0
+User=gpusim
+ExecStop=-/bin/nvidia-docker stop %n
+ExecStartPre=-/bin/nvidia-docker stop %n
+ExecStartPre=-/bin/nvidia-docker rm %n
+ExecStartPre=-/bin/nvidia-docker pull klorton/gpusimilarity:latest
+ExecStart=/bin/nvidia-docker run --net=host --name %n \
+-v /PATH/TO/FSIM:/mnt/fsim klorton/gpusimilarity:latest \
+python3 /gpusimilarity/bld/python/gpusim_server.py --port 8080 \
+/mnt/fsim/YOUR_FSIM_FILE.fsim
+
+[Install]
+WantedBy=multi-user.target

--- a/python/gpusim_server.py
+++ b/python/gpusim_server.py
@@ -34,7 +34,7 @@ search_mutex = QtCore.QMutex()
 try:
     from gpusim_server_loc import GPUSIM_EXEC  # Used in schrodinger env
 except ImportError:
-    GPUSIM_EXEC = './gpusimserver'
+    GPUSIM_EXEC = '../gpusimserver'
 
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):

--- a/python/gpusim_server.py
+++ b/python/gpusim_server.py
@@ -34,7 +34,8 @@ search_mutex = QtCore.QMutex()
 try:
     from gpusim_server_loc import GPUSIM_EXEC  # Used in schrodinger env
 except ImportError:
-    GPUSIM_EXEC = '../gpusimserver'
+    script_path = os.path.split(__file__)[0]
+    GPUSIM_EXEC = os.path.join(script_path, '..', 'gpusimserver')
 
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):


### PR DESCRIPTION
This will be the preferred way of building/executing GPUSimilarity going forward.  We'll also post public containers at release version so people don't have to worry about building as long as they have nvidia-docker installed.

Further documentation required for all that to be possible.