### PR TITLE
Enable compatibility with C++14 and Qt 5.14+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 set(QT_MINIMAL_VERSION 5.2.0)
 set(BOOST_MINIMAL_VERSION 1.54.0)
 set(CUDA_MINIMAL_VERSION 8.0.61)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 
 # ccmake -DCMAKE_CUDA_COMPILER=path/to/nvcc ../gpusimilarity
@@ -58,14 +58,14 @@ if (DOXYGEN_FOUND) # make doc_doxygen
 endif()
 
 add_library(gpusim gpusim.cpp fingerprintdb_cuda.cpp fingerprintdb_cuda.cu calculation_functors.cpp)
-set_property(TARGET gpusim PROPERTY CUDA_STANDARD 11)
+set_property(TARGET gpusim PROPERTY CUDA_STANDARD 14)
 target_include_directories(gpusim PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>)
 
 
 add_executable(gpusimserver main.cpp)
-# Force C++11
+# Force C++14
 target_compile_features(gpusimserver PRIVATE cxx_override)
 
 # Force -fPIC on executable. This is Qt bug.

--- a/gpusim.cpp
+++ b/gpusim.cpp
@@ -417,7 +417,7 @@ void GPUSimServer::incomingSearchRequest()
     vector<char*> results_smiles, results_ids;
     vector<float> results_scores;
 
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     unsigned long approximate_result_count = 0;

--- a/qstring_hash.h
+++ b/qstring_hash.h
@@ -2,9 +2,13 @@
 #include <QString>
 #include <functional>
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+
 namespace std
 {
 template <> struct hash<QString> {
     std::size_t operator()(const QString& s) const { return qHash(s); }
 };
 } // namespace std
+
+#endif /* QT_VERSION */


### PR DESCRIPTION
- Conditionally use back-ported template specialization
- Replace depcreated timer class
- Bump required language standard to C++14 to avoid warning (errors) with more recent CUDA toolkits than CUDA 9 (caused by Thrust)